### PR TITLE
Fix colored output flag

### DIFF
--- a/crates/rstrace/src/main.rs
+++ b/crates/rstrace/src/main.rs
@@ -107,9 +107,10 @@ struct Cli {
 
     #[clap(
         long = "color",
-        help = "Enable colored output (default)",
-        action = ArgAction::SetTrue,
-        default_value_t = true
+        help = "Enable colored output",
+        action = ArgAction::Set,
+        default_value_t = true,
+        value_name = "BOOL"
     )]
     color: bool,
 


### PR DESCRIPTION
Previously, it was impossible to disable colored output, since the argument action on `--color` was `SetTrue`